### PR TITLE
chore: Add GitHub Actions workflow to automatically close linked issues upon merging pull requests into the dev branch.

### DIFF
--- a/.github/workflows/close-issue-on-dev.yml
+++ b/.github/workflows/close-issue-on-dev.yml
@@ -1,0 +1,47 @@
+name: Auto Close Issue on Dev Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - dev
+
+jobs:
+  close-linked-issue:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Close Issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body;
+            const repo_owner = context.repo.owner;
+            const repo_name = context.repo.repo;
+            
+            // Regex to find "closes #123", "fixes #123", etc.
+            const re = /(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+#(\d+)/gi;
+            let match;
+            
+            while ((match = re.exec(body)) !== null) {
+              const issue_number = match[1];
+              console.log(`Found linked issue: ${issue_number}. Closing...`);
+              
+              await github.rest.issues.update({
+                owner: repo_owner,
+                repo: repo_name,
+                issue_number: issue_number,
+                state: 'closed',
+                state_reason: 'completed'
+              });
+              
+              await github.rest.issues.createComment({
+                owner: repo_owner,
+                repo: repo_name,
+                issue_number: issue_number,
+                body: `Closed automatically via PR #${context.payload.pull_request.number} merged into dev.`
+              });
+            }


### PR DESCRIPTION
## Auto Close Issue on Dev Merge

### Description
This PR adds a GitHub Actions workflow that automatically closes linked issues when a pull request is merged into the `dev` branch. This automation streamlines our development workflow by reducing manual issue management overhead.

### What's New
- **Automated Issue Closure**: When a PR is merged to `dev`, any issues referenced with keywords (`closes`, `fixes`, `resolves`, etc.) in the PR description are automatically closed
- **Audit Trail**: Adds a comment to each closed issue indicating which PR triggered the closure
- **Smart Detection**: Uses regex pattern matching to find all linked issues in PR descriptions

### Technical Details
**Workflow Trigger:**
- Runs on `pull_request` events with type `closed` targeting the `dev` branch
- Only executes if the PR was actually merged (not just closed)

**Permissions:**
- `issues: write` - to close issues and add comments
- `pull-requests: read` - to read PR body content

**Supported Keywords:**
The workflow recognizes the following keywords followed by `#<issue_number>`:
- `close`, `closes`, `closed`
- `fix`, `fixes`, `fixed`
- `resolve`, `resolves`, `resolved`

### Example Usage
In your PR description, simply reference issues like:
`Closes #15 Fixes #23`

### Benefits
- ✅ Reduces manual work for maintainers
- ✅ Ensures issues are closed promptly when work is merged
- ✅ Maintains clear traceability between PRs and issues
- ✅ Improves project management workflow

**Note:** This workflow only affects the `dev` branch. Issues will be closed when PRs merge to `dev`, aligning with our development workflow where `dev` is the primary integration branch.

Closes #15 